### PR TITLE
Update web implementation for accurate types

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import { User, Authentication } from "./user";
+import { User, WebAuthentication, iOSAuthentication } from "./user";
 
 declare module "@capacitor/core" {
   interface PluginRegistry {
@@ -6,13 +6,9 @@ declare module "@capacitor/core" {
   }
 }
 
-/** On iOS, refresh returns an extra field */
-interface RefreshData extends Authentication {
-  refreshToken?: string;
-}
-
 export interface GoogleAuthPlugin {
   signIn(): Promise<User>;
-  refresh(): Promise<RefreshData>;
+  /** Implemented on Web and iOS, not Android */
+  refresh(): Promise<WebAuthentication | iOSAuthentication>;
   signOut(): Promise<void>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,9 +1,18 @@
+import { User, Authentication } from "./user";
+
 declare module "@capacitor/core" {
   interface PluginRegistry {
     GoogleAuth: GoogleAuthPlugin;
   }
 }
 
+/** On iOS, refresh returns an extra field */
+interface RefreshData extends Authentication {
+  refreshToken?: string;
+}
+
 export interface GoogleAuthPlugin {
-  signIn(options: { value: string }): Promise<{value: string}>;
+  signIn(): Promise<User>;
+  refresh(): Promise<RefreshData>;
+  signOut(): Promise<void>;
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,17 +1,39 @@
-export interface User {
+interface CommonUser {
     id: string;
     email: string;
     
     name: string;
     familyName: string;
     givenName: string;
-    imageUrl: string;
+    imageUrl?: string;
 
     serverAuthCode: string;
+}
+
+export interface WebUser extends CommonUser {
+    authentication: WebAuthentication;
+}
+
+interface iOSUser extends CommonUser {
+    authentication: iOSAuthentication;
+}
+
+interface AndroidUser extends CommonUser {
+    idToken: string;
     authentication: Authentication;
 }
 
-export interface Authentication {
-    accessToken: string;
+export type User = WebUser | iOSUser | AndroidUser;
+
+interface Authentication {
     idToken: string;
+}
+
+export interface WebAuthentication extends Authentication {
+    accessToken: string;
+}
+
+export interface iOSAuthentication extends Authentication {
+    accessToken: string;
+    refreshToken: string;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 import { WebPlugin } from '@capacitor/core';
 import { GoogleAuthPlugin } from './definitions';
-import { User, Authentication } from './user';
+import { User } from './user';
 
 // @ts-ignore
 import config from '../../../../../capacitor.config.json';
@@ -57,8 +57,8 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     });
   }
 
-  async signIn(): Promise<any> {
-    return new Promise(async (resolve, reject) => {
+  async signIn() {
+    return new Promise<User>(async (resolve, reject) => {
       try {
         var serverAuthCode: string;
         var needsOfflineAccess = false;
@@ -92,7 +92,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     });
   }
 
-  async refresh(): Promise<Authentication> {
+  async refresh() {
     const authResponse = await gapi.auth2.getAuthInstance().currentUser.get().reloadAuthResponse()
     return {
       accessToken: authResponse.access_token,
@@ -100,7 +100,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     }
   }
 
-  async signOut(): Promise<any> {
+  async signOut() {
     return gapi.auth2.getAuthInstance().signOut();
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 import { WebPlugin } from '@capacitor/core';
 import { GoogleAuthPlugin } from './definitions';
-import { User } from './user';
+import { WebUser } from './user';
 
 // @ts-ignore
 import config from '../../../../../capacitor.config.json';
@@ -58,7 +58,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
   }
 
   async signIn() {
-    return new Promise<User>(async (resolve, reject) => {
+    return new Promise<WebUser>(async (resolve, reject) => {
       try {
         var serverAuthCode: string;
         var needsOfflineAccess = false;
@@ -83,8 +83,11 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
           await googleUser.reloadAuthResponse();
         }
 
-        const user = this.getUserFrom(googleUser);
-        user.serverAuthCode = serverAuthCode;
+        const user = {
+          ...this.getUserFrom(googleUser),
+          serverAuthCode: serverAuthCode
+        };
+
         resolve(user);
       } catch (error) {
         reject(error);
@@ -111,22 +114,22 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
     });
   }
 
-  private getUserFrom(googleUser: gapi.auth2.GoogleUser): User {
-    const user = {} as User;
+  private getUserFrom(googleUser: gapi.auth2.GoogleUser) {
     const profile = googleUser.getBasicProfile();
-
-    user.email = profile.getEmail();
-    user.familyName = profile.getFamilyName();
-    user.givenName = profile.getGivenName();
-    user.id = profile.getId();
-    user.imageUrl = profile.getImageUrl();
-    user.name = profile.getName();
-
     const authResponse = googleUser.getAuthResponse(true);
-    user.authentication = {
-      accessToken: authResponse.access_token,
-      idToken: authResponse.id_token
-    }
+
+    const user = {
+      email: profile.getEmail(),
+      familyName: profile.getFamilyName(),
+      givenName: profile.getGivenName(),
+      id: profile.getId(),
+      imageUrl: profile.getImageUrl(),
+      name: profile.getName(),
+      authentication: {
+        accessToken: authResponse.access_token,
+        idToken: authResponse.id_token
+      }
+    };
 
     return user;
   }


### PR DESCRIPTION
The existing `definitions.ts` is pretty much just the original boilerplate from the Capacitor CLI, and doesn't match (or even mention) all the functions that now get exported. There are more functions than these three in the web implementation, but these are the only ones that get exported by each implementation. I also removed the manual type declarations from the web implementation, since they're already defined by the `implements GoogleAuthPlugin` part.

### Update
Turns out the implementations aren't consistent about that, either. I reorganized the types so that the `definitions.ts` file reflects all the possible return values from the native implementations, and moved a couple of things in the web implementation so that we don't have the `const user = {} as User`, preventing type checking from working.