### PR TITLE
Allow for android / iOS specific forceCodeForRefreshToken overrides

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -33,6 +33,10 @@ public class GoogleAuth extends Plugin {
     if (forceRefreshToken != null) {
       forceCodeForRefreshToken = forceRefreshToken;
     }
+    Boolean forceRefreshTokenAndroidSpecific = (Boolean) getConfigValue("forceCodeForRefreshTokenAndroid");
+    if (forceRefreshToken != null) {
+      forceCodeForRefreshToken = forceRefreshTokenAndroidSpecific;
+    }
 
     GoogleSignInOptions.Builder googleSignInBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(clientId)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -28,6 +28,9 @@ public class GoogleAuth: CAPPlugin {
         if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshToken") as? Bool {
             forceAuthCode = forceAuthCodeConfig;
         }
+        if let forceAuthCodeConfig = getConfigValue("forceCodeForRefreshTokenIOS") as? Bool {
+            forceAuthCode = forceAuthCodeConfig;
+        }
         NotificationCenter.default.addObserver(self, selector: #selector(handleOpenUrl(_ :)), name: Notification.Name(CAPNotifications.URLOpen.name()), object: nil);
     }
     


### PR DESCRIPTION
Allows platform specific forceCodeForRefreshToken overrides so that we can have the behaviour on iOS where we need it, but not have it on android where it just causes people to be promoted more often. 