### PR TITLE
Fix check for android specific forceCodeForRefreshToken override

### DIFF
--- a/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
+++ b/android/src/main/java/com/codetrixstudio/capacitor/GoogleAuth/GoogleAuth.java
@@ -34,7 +34,7 @@ public class GoogleAuth extends Plugin {
       forceCodeForRefreshToken = forceRefreshToken;
     }
     Boolean forceRefreshTokenAndroidSpecific = (Boolean) getConfigValue("forceCodeForRefreshTokenAndroid");
-    if (forceRefreshToken != null) {
+    if (forceRefreshTokenAndroidSpecific != null) {
       forceCodeForRefreshToken = forceRefreshTokenAndroidSpecific;
     }
 


### PR DESCRIPTION
Fixes a bug that wasn't exposed due to always having forceRefreshTokenAndroidSpecific defined in our app.