### PR TITLE
Pin capacitor dependencies so building still works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,23 @@
   "requires": true,
   "dependencies": {
     "@capacitor/android": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.5.1.tgz",
-      "integrity": "sha512-dubGu+Im5uqdkLBX9c0azGF1v3AY1HTlWxZmjn7qN48AXJL3woxCi4TVv2MEXJRxgfQq5Aunqu6rsmF/bDaOHw==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.4.7.tgz",
+      "integrity": "sha512-7jcmwheo94dJEOX1z4r3SlZrL+MvESav1xsUwC5ydLFZCpuvBKJ0szbDNWzCAglgpXmW9hC0WdwYBErgDrDPRg==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.5.1.tgz",
-      "integrity": "sha512-3ncsiM+G1w4/osKbtPXGfHGOp/A1WKein1EVDX3O151aqjNf44F+n/zweZG1XvtOmY4AHNaQcHYO/s9nMOmPOw==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.4.7.tgz",
+      "integrity": "sha512-ZPzXXQ4EPwR/ZhNDkmlxyzw4FvquIl/ROj8HMMM0MEd4xZfM8ulNGPIL6br9TWdlFLGBKq40eymPZjKaivGnig==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@capacitor/ios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.5.1.tgz",
-      "integrity": "sha512-6b8o/U87KIRWj3OLT+RrStTS56FWF7/dJkFe75XS5PBZPlWl8dKB3MUb3oKpWX5E7Y105Yo8CA/fKOSk8QQzsg==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.4.7.tgz",
+      "integrity": "sha512-XKYU67ZM+yY4/vDJ3ZVfs+phjtWK8TcKwq75fGoxB9PKXuCmMi5bihPuA3Xs/sIFXuozpnaYnspp0eTRJ7bG0w==",
       "dev": true
     },
     "@types/gapi": {
@@ -40,9 +40,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "typescript": {
       "version": "3.4.5",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "author": "CodetrixStudio",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^2.4.7"
   },
   "devDependencies": {
-    "@capacitor/android": "latest",
-    "@capacitor/ios": "latest",
+    "@capacitor/android": "^2.4.7",
+    "@capacitor/ios": "^2.4.7",
     "@types/gapi": "0.0.36",
     "@types/gapi.auth2": "0.0.50",
     "typescript": "^3.2.4"


### PR DESCRIPTION
Seems it tries to install `@capacitor/core@3`, which uses `import type {} from ""` syntax, which TypeScript 3.2, the version it's pinned to, doesn't support. 