### PR TITLE
Revert to older GoogleSignIn version

### DIFF
--- a/CodetrixStudioCapacitorGoogleAuth.podspec
+++ b/CodetrixStudioCapacitorGoogleAuth.podspec
@@ -10,6 +10,6 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'GoogleSignIn', '~> 6.2.4'
+    s.dependency 'GoogleSignIn', '~> 6.0.2'
     s.static_framework = true
   end

--- a/CodetrixStudioCapacitorGoogleAuth.podspec
+++ b/CodetrixStudioCapacitorGoogleAuth.podspec
@@ -10,6 +10,6 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'GoogleSignIn', '~> 6.0.2'
+    s.dependency 'GoogleSignIn', '6.0.2'
     s.static_framework = true
   end


### PR DESCRIPTION
The never version errors when we supply a complete list of scopes we'd like. 

Some discussion on possible reasons for why here. 
https://github.com/react-native-google-signin/google-signin/issues/1070

Changelog for GoogleSignIn https://developers.google.com/identity/sign-in/ios/release

Specifically this change is likely to be the one causing us issues https://github.com/google/GoogleSignIn-iOS/pull/68

Error https://developers.google.com/identity/sign-in/ios/reference/Enums/GIDSignInErrorCode